### PR TITLE
remove '.only()' from tests

### DIFF
--- a/test/sand/application.test.js
+++ b/test/sand/application.test.js
@@ -128,7 +128,7 @@ describe('app.inspect()', function(){
   });
 });
 
-describe.only('Context', () => {
+describe('Context', () => {
   let app = new sand({
     configPath: path.resolve(__dirname + '/helpers/config.js')
   });


### PR DESCRIPTION
remove an `.only` clause that was left in the tests