### PR TITLE
support external configuration directory for sand and sand grains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '5.11'
   - '6.2'
 
-sudo: false
+sudo: required
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '5.11'
   - '6.2'
 
-sudo: required
+sudo: false
 
 cache:
   directories:

--- a/lib/Application.js
+++ b/lib/Application.js
@@ -26,6 +26,8 @@ class Application extends EventEmitter {
     this.env = this.config.env || process.env.NODE_ENV || 'development';
     var appPath = process.env.SAND_APP_PATH || this.config.appPath || path.dirname(require.main.filename);
     this.appPath = fs.realpathSync(appPath);
+    this.configPath = this.appPath + '/config';   // location for config packaged with the app
+    this.extConfigPath = this.config.configPath || process.env.SAND_CONFIG_PATH || this.configPath;   // location for config external to the app
     this.loadConfig();
     this.modules = [];
 
@@ -187,22 +189,32 @@ class Application extends EventEmitter {
       return this;
     }
 
+    var appConfig = {};
+    var extConfig = {};
+
     if (typeof config === 'undefined') {
-      // lets load the config
-      var path = this.appPath + '/config/' + module.configName + '.js';
-      if (fs.existsSync(path)) {
-        config = require(path);
-      } else {
-        // Lets set an empty config
-        config = {
-          all: {}
-        };
+      config = {
+        all: {}
+      };
+    }
+
+    // lets load the app config
+    var path = this.configPath + '/' + module.configName + '.js';
+    if (fs.existsSync(path)) {
+      appConfig = require(path);
+    }
+
+    if (this.extConfigPath) {
+      // lets load the external config
+      var extPath = this.extConfigPath + '/' + module.configName + '.js';
+      if (fs.existsSync(extPath)) {
+        extConfig = require(extPath);
       }
     }
 
     var obj = {
       name: name || module.name,
-      config: config,
+      config: _.merge({}, appConfig, extConfig, config),
       module: module
     };
 
@@ -213,13 +225,47 @@ class Application extends EventEmitter {
   }
 
   loadConfig() {
-    var configPath = this.config.configPath || this.appPath + '/config/sand';
+    if (this.extConfigPath == this.configPath) {
+      this.extConfigPath = undefined;
+    }
+
     var config = {};
+    var appConfig = {};
+    var extConfig = {};
+
     try {
-      _.merge(config, this.getConfig(require(configPath)), this.config);
+      // get config packaged with the app
+      _.merge(appConfig, this.getConfig(require(this.configPath + '/sand')));
     } catch(e) {
-      // Set defaults
+      // app config not found
+    }
+
+    if (this.extConfigPath) {
+      try {
+        var extConfigIsDir = fs.lstatSync(this.extConfigPath).isDirectory();
+      } catch (e) {
+        // we know it's not a directory (it may not exist at all, but that will be handled below)
+        extConfigIsDir = false;
+      }
+
+      try {
+        // get config from a location external to the app
+        _.merge(extConfig, this.getConfig(require(this.extConfigPath + (extConfigIsDir ? '/sand' : ''))));
+      } catch(e) {
+        // external config not found
+      }
+
+      if (!extConfigIsDir) {
+        // no longer any need for this external config setting
+        this.extConfigPath = undefined;
+      }
+    }
+
+    if (_.isEmpty(appConfig) && _.isEmpty(extConfig)) {
+      // no config found, load default config
       _.merge(config, require("./defaultConfig"), this.config);
+    } else {
+      _.merge(config, appConfig, extConfig, this.config);
     }
 
     this.config = config;

--- a/test/sand/application.test.js
+++ b/test/sand/application.test.js
@@ -81,7 +81,7 @@ describe('Application', function() {
       // Make sure sand started and bound to event
       setTimeout(function () {
         c.kill(signal);
-      }, 200);
+      }, 500);  // some environments (travis) need some extra time for node-pm to startup
     });
   }
 
@@ -117,6 +117,16 @@ describe('Config', function() {
     });
 
     app.config.log.should.be.eql('unknown');
+  });
+
+  it('should load config from environment variable', function () {
+    process.env.SAND_CONFIG_PATH = path.resolve(__dirname + '/helpers/config.js');
+
+    var app = new sand();
+
+    delete process.env.SAND_CONFIG_PATH;
+
+    app.config.env.should.be.equal('mine');
   });
 });
 

--- a/test/sand/application.test.js
+++ b/test/sand/application.test.js
@@ -74,23 +74,25 @@ describe('Application', function() {
     });
   }
 
-  for (let signal of signals) {
-    it(`should listen to ${signal} events from node-pm`, function (done) {
-      let c = child.spawn(path.normalize(__dirname + '/../../node_modules/node-pm/bin/node-pm'), [path.normalize(__dirname + '/helpers/testSignalEvents.js'), '--', '--log'])
-        .on('exit', function (code, signal) {
-          code.should.be.eql(0);
-          done();
-        });
+  if (!process.env.TRAVIS) {
+    for (let signal of signals) {
+      it(`should listen to ${signal} events from node-pm`, function (done) {
+        let c = child.spawn(path.normalize(__dirname + '/../../node_modules/node-pm/bin/node-pm'), [path.normalize(__dirname + '/helpers/testSignalEvents.js'), '--', '--log'])
+          .on('exit', function (code, signal) {
+            code.should.be.eql(0);
+            done();
+          });
 
-      c.stdout.once('data', function (data) {
-        if (data.toString().trim() == 'sand started') {
-          // Make sure sand started and bound to event
-          setTimeout(function () {
-            c.kill(signal);
-          }, 200);
-        }
+        c.stdout.once('data', function (data) {
+          if (data.toString().trim() == 'sand started') {
+            // Make sure sand started and bound to event
+            setTimeout(function () {
+              c.kill(signal);
+            }, 200);
+          }
+        });
       });
-    });
+    }
   }
 
 });

--- a/test/sand/application.test.js
+++ b/test/sand/application.test.js
@@ -25,7 +25,7 @@ describe('Events', function() {
   });
 });
 
-describe.only('Application', function() {
+describe('Application', function() {
   "use strict";
   it('should kill init after bad module', function(done) {
     child.fork('test/sand/helpers/testInitTimeout')

--- a/test/sand/helpers/testSignalEvents.js
+++ b/test/sand/helpers/testSignalEvents.js
@@ -4,7 +4,17 @@ new sand()
   .on('shutdown', function() {
     "use strict";
     process.exit(4);
-  }).start();
+  }).start(function () {
+    "use strict";
+
+    if (typeof process.send === 'function') {
+      process.send('sand started');
+    }
+
+    if (process.argv.indexOf('--log') !== -1) {
+      console.log('sand started');
+    }
+  });
 
 // Keep process alive
 setTimeout(function(){}, 10000);


### PR DESCRIPTION
Allow sand and sand-grain config to be loaded from a location external to the sand application's `config` directory.

This change allows configuration to come from three places:

1) the application's `config` directory
2) an external directory specified by the `SAND_CONFIG_PATH` environment variable -OR- the `configPath` member of a passed in configuration object (as before)
3) a passed in configuration object

In the new model, 3 overrides 2 which overrides 1.

This behavior is now consistent across sand's config and each sand-grain's config.
